### PR TITLE
feat(auth): add env-based reference API token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,8 @@ DATABASE_URL=./openfiler.db
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Token API de référence (optionnel)
+# Si défini, ce token est accepté pour les uploads sans passer par l'interface.
+# Il n'apparaît pas dans l'application et ne peut pas être supprimé.
+# OPENFILER_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ DATABASE_URL=./openfiler.db
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Token API de référence (optionnel)
+# OPENFILER_API_TOKEN=
 ```
 
 | Variable | Description | Requis |
@@ -163,6 +166,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 | `BETTER_AUTH_URL` | URL de base de l'application | ✅ |
 | `DATABASE_URL` | Chemin vers le fichier SQLite (ou URL PostgreSQL/MySQL) | ✅ |
 | `NEXT_PUBLIC_APP_URL` | URL publique de l'app (utilisée par le client auth) | ✅ |
+| `OPENFILER_API_TOKEN` | Token API de référence défini dans l'environnement. Accepté pour les uploads sans passer par l'interface — invisible et non-supprimable dans l'app. | ❌ |
 
 ### Base de données
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -27,8 +27,13 @@ export async function POST(request: NextRequest) {
 
     if (authHeader?.startsWith("Bearer ")) {
       const token = authHeader.slice(7);
-      const row = db.prepare("SELECT id FROM api_token WHERE token = ?").get(token);
-      authenticated = !!row;
+      const envToken = process.env.OPENFILER_API_TOKEN;
+      if (envToken && token === envToken) {
+        authenticated = true;
+      } else {
+        const row = db.prepare("SELECT id FROM api_token WHERE token = ?").get(token);
+        authenticated = !!row;
+      }
     }
 
     if (!authenticated) {


### PR DESCRIPTION
If OPENFILER_API_TOKEN is set in .env, it is accepted as a valid Bearer token for uploads. It never appears in the app UI and cannot be deleted. Closes #34